### PR TITLE
Prevent SecurityExceptions to be forwarded to the host

### DIFF
--- a/api/src/main/java/com/google/android/apps/dashclock/api/host/DashClockHost.java
+++ b/api/src/main/java/com/google/android/apps/dashclock/api/host/DashClockHost.java
@@ -147,7 +147,7 @@ public abstract class DashClockHost {
             if (!connect()) {
                 mHandler.sendEmptyMessageDelayed(MSG_RECONNECT, AUTO_RECONNECT_DELAY);
             }
-        } catch (NoMultiplexerAvailableException ex) {
+        } catch (NoMultiplexerAvailableException | SecurityException ex) {
             // Notify the implementation that the multiplexer isn't available
             mHandler.obtainMessage(MSG_NOTIFY_MUX_NOT_AVAILABLE).sendToTarget();
         }


### PR DESCRIPTION
If the installed version of DashClock is a one which doesn't support
the new host api, we will get a SecurityException when trying to access
the DashClockService forwaded to the host client, instead of receive a
onMultiplexerChangedDetected(false) event.

Signed-off-by: Jorge Ruesga <jorge@ruesga.com>