### PR TITLE
Update Dutch (nl) translation

### DIFF
--- a/main/src/main/res/values-nl/pref_strings.xml
+++ b/main/src/main/res/values-nl/pref_strings.xml
@@ -29,13 +29,6 @@
         <item>75% zichtbaar</item>
         <item>Niet transparant</item>
     </string-array>
-    <string-array name="pref_background_opacity_values" translatable="false">
-        <item>0</item>
-        <item>25</item>
-        <item>50</item>
-        <item>75</item>
-        <item>100</item>
-    </string-array>
     <string name="pref_foreground_color_description">Kleur van tekst en iconen</string>
     <string name="pref_aggressive_centering_title">Altijd centreren</string>
     <string name="pref_aggressive_centering_description">Kan erin resulteren dat de klok bij verschillende widgetstadia verspringt</string>
@@ -44,11 +37,6 @@
         <item>Verborgen</item>
         <item>In uitgeklapt widget</item>
         <item>In applicatielijst</item>
-    </string-array>
-    <string-array name="pref_settings_button_values" translatable="false">
-        <item>hidden</item>
-        <item>inwidget</item>
-        <item>inlauncher</item>
     </string-array>
     <string name="pref_hide_clock_title">Klok verbergen</string>
     <string name="pref_hide_clock_description">Verberg de klok en toon alleen de extensies</string>
@@ -63,10 +51,6 @@
         <item>°F</item>
         <item>°C</item>
     </string-array>
-    <string-array name="pref_weather_units_values" translatable="false">
-        <item>f</item>
-        <item>c</item>
-    </string-array>
     <string name="pref_weather_location_title">Locatie</string>
     <string name="pref_weather_location_query_hint">Zoek een locatie</string>
     <string name="pref_weather_location_automatic">Automatisch</string>
@@ -77,10 +61,6 @@
     <string-array name="pref_gmail_label_display_names">
         <item>Inbox</item>
         <item>Postvak Prioreteit</item>
-    </string-array>
-    <string-array name="pref_gmail_label_inbox_values" translatable="false">
-        <item>i</item>
-        <item>p</item>
     </string-array>
 
     <string name="pref_gmail_accounts_title">Geef ongelezen aantal weer voor de accounts</string>
@@ -98,14 +78,6 @@
         <item>24 uur</item>
         <item>2 dagen</item>
         <item>week</item>
-    </string-array>
-    <string-array name="pref_calendar_look_ahead_hours_values" translatable="false">
-        <item>3</item>
-        <item>6</item>
-        <item>12</item>
-        <item>24</item>
-        <item>48</item>
-        <item>168</item>
     </string-array>
     <string name="pref_calendar_selected_title">Selecteer agenda\'s om weer te geven</string>
     <plurals name="pref_calendar_selected_summary_template">
@@ -128,12 +100,6 @@
         <item>Schuiven</item>
         <item>Fade</item>
         <item>Geen (beschadigt mogelijk scherm)</item>
-    </string-array>
-    <string-array name="pref_daydream_animation_values" translatable="false">
-        <item>pendulum</item>
-        <item>slide</item>
-        <item>fade</item>
-        <item>none</item>
     </string-array>
     <string name="pref_daydream_system_settings_title">Dagdroom-systeeminstellingen</string>
 

--- a/main/src/main/res/values-nl/pref_strings.xml
+++ b/main/src/main/res/values-nl/pref_strings.xml
@@ -17,8 +17,41 @@
 <resources>
     <!-- Advanced widget preferences -->
     <string name="pref_clock_shortcut_title">Klok-snelkoppeling</string>
+    <string name="pref_background_title">Achtergrond</string>
+    <string name="pref_foreground_color_title">Voorgrondkleur</string>
+    <string name="pref_homescreen_title">Startscherm-widget</string>
+    <string name="pref_lockscreen_title">Vergrendelscherm-widget</string>
+    <string name="pref_background_opacity_title">Achtergrond-zichtbaarheid</string>
+    <string-array name="pref_background_opacity_display_names">
+        <item>Volledig transparant</item>
+        <item>25% zichtbaar</item>
+        <item>50% zichtbaar</item>
+        <item>75% zichtbaar</item>
+        <item>Niet transparant</item>
+    </string-array>
+    <string-array name="pref_background_opacity_values" translatable="false">
+        <item>0</item>
+        <item>25</item>
+        <item>50</item>
+        <item>75</item>
+        <item>100</item>
+    </string-array>
+    <string name="pref_foreground_color_description">Kleur van tekst en iconen</string>
     <string name="pref_aggressive_centering_title">Altijd centreren</string>
-    <string name="pref_aggressive_centering_description">Kan erin resulteren dat de klok bij verschillende widget stadia verspringt</string>
+    <string name="pref_aggressive_centering_description">Kan erin resulteren dat de klok bij verschillende widgetstadia verspringt</string>
+    <string name="pref_settings_button_title">Instellingen-knop</string>
+    <string-array name="pref_settings_button_display_names">
+        <item>Verborgen</item>
+        <item>In uitgeklapt widget</item>
+        <item>In applicatielijst</item>
+    </string-array>
+    <string-array name="pref_settings_button_values" translatable="false">
+        <item>hidden</item>
+        <item>inwidget</item>
+        <item>inlauncher</item>
+    </string-array>
+    <string name="pref_hide_clock_title">Klok verbergen</string>
+    <string name="pref_hide_clock_description">Verberg de klok en toon alleen de extensies</string>
 
     <!-- Universal settings preferences -->
     <string name="pref_shortcut_title">Snelkoppeling</string>
@@ -30,12 +63,24 @@
         <item>°F</item>
         <item>°C</item>
     </string-array>
+    <string-array name="pref_weather_units_values" translatable="false">
+        <item>f</item>
+        <item>c</item>
+    </string-array>
+    <string name="pref_weather_location_title">Locatie</string>
+    <string name="pref_weather_location_query_hint">Zoek een locatie</string>
+    <string name="pref_weather_location_automatic">Automatisch</string>
+    <string name="pref_weather_location_automatic_description">Gebaseerd op je huidige locatie.</string>
 
     <!-- Gmail -->
     <string name="pref_gmail_label_title">Geef ongelezen aantal weer voor</string>
     <string-array name="pref_gmail_label_display_names">
         <item>Inbox</item>
         <item>Postvak Prioreteit</item>
+    </string-array>
+    <string-array name="pref_gmail_label_inbox_values" translatable="false">
+        <item>i</item>
+        <item>p</item>
     </string-array>
 
     <string name="pref_gmail_accounts_title">Geef ongelezen aantal weer voor de accounts</string>
@@ -54,17 +99,50 @@
         <item>2 dagen</item>
         <item>week</item>
     </string-array>
+    <string-array name="pref_calendar_look_ahead_hours_values" translatable="false">
+        <item>3</item>
+        <item>6</item>
+        <item>12</item>
+        <item>24</item>
+        <item>48</item>
+        <item>168</item>
+    </string-array>
     <string name="pref_calendar_selected_title">Selecteer agenda\'s om weer te geven</string>
     <plurals name="pref_calendar_selected_summary_template">
         <item quantity="one">%1$d van %2$d agenda geselecteerd</item>
         <item quantity="other">%1$d van %2$d agenda\'s geselecteerd</item>
     </plurals>
     <string name="pref_calendar_custom_visibility_title">Aangepaste agenda-zichtbaarheid</string>
-    <string name="pref_calendar_custom_visibility_description">Laat alle agenda\'s uit de Agenda-app zien op het moment dat dit uitgevinkt is</string>
+    <string name="pref_calendar_custom_visibility_description">Alle agenda\'s uit de Agenda-app worden getoond op het moment dat dit is uitgevinkt.</string>
     <string name="pref_calendar_show_all_day_title">Laat \'Hele dag\'-afspraken zien</string>
-    <string name="pref_calendar_show_all_day_description">Laat \'Hele dag\'-afspraken zien zoals verjaardagen</string>
+    <string name="pref_calendar_show_all_day_description">Laat \'Hele dag\'-afspraken zoals verjaardagen zien</string>
 
     <!-- Daydream preferences -->
-    <!--<string name="pref_daydream_color_title">Foreground color</string>-->
-    <!--<string name="pref_daydream_system_settings_title">System Daydream settings</string>-->
+    <string name="pref_daydream_color_title">Voorgrondkleur</string>
+    <string name="pref_daydream_color_description">Kleur van tekst en iconen in Dagdroom-modus</string>
+    <string name="pref_daydream_night_mode_title">Nachtmodus</string>
+    <string name="pref_daydream_night_mode_description">Erg donker scherm (voor donkere kamers)</string>
+    <string name="pref_daydream_animation_title">Animatie</string>
+    <string-array name="pref_daydream_animation_display_names">
+        <item>Slingeren (standaard)</item>
+        <item>Schuiven</item>
+        <item>Fade</item>
+        <item>Geen (beschadigt mogelijk scherm)</item>
+    </string-array>
+    <string-array name="pref_daydream_animation_values" translatable="false">
+        <item>pendulum</item>
+        <item>slide</item>
+        <item>fade</item>
+        <item>none</item>
+    </string-array>
+    <string name="pref_daydream_system_settings_title">Dagdroom-systeeminstellingen</string>
+
+    <!-- World readability -->
+    <string name="pref_force_world_readable_title">Sta andere apps toe alle extensies te zien</string>
+    <string name="pref_force_world_readable_description">Sta andere apps toe om informatie van al je extensies te zien, inclusief je agenda, contacten, etc.</string>
+
+    <string name="force_world_readable_dialog_description">Een andere app vraagt toegang tot de mogelijkheid om informatie van al je DashClock-extensies te zien, inclusief privé-extensies zoals je agenda, contacten, etc. Wil je dit <b>toestaan voor alle apps</b>?</string>
+
+    <string name="force_world_readable_dialog_no">Annuleren</string>
+    <string name="force_world_readable_dialog_yes">Toestaan voor alle apps</string>
 </resources>

--- a/main/src/main/res/values-nl/strings.xml
+++ b/main/src/main/res/values-nl/strings.xml
@@ -15,8 +15,10 @@
   -->
 
 <resources>
-    <string name="permission_desc_read_extension_data">Sta dataverzoeken van DashClock-extensies toe</string>
-    <string name="permission_label_read_extension_data">Verzoek data van DashClock-extensies</string>
+    <string name="app_name" translatable="false">DashClock Widget</string>
+    <string name="widget_label" translatable="false">DashClock</string>
+
+    <string name="status_none" translatable="false">––</string>
 
     <string name="settings">Instellingen</string>
     <string name="more_options">Meer opties</string>
@@ -24,10 +26,10 @@
     <string name="simple_date_format">E, MMM dd</string>
 
     <!-- Configuration -->
-    <string name="title_configure">DashClock Widget instellen</string>
+    <string name="title_configure">DashClock-instellingen</string>
     <string name="section_extensions">Extensies</string>
     <string name="section_appearance">Uiterlijk</string>
-    <!--<string name="section_daydream">Daydream</string>-->
+    <string name="section_daydream">Dagdroom</string>
     <string name="section_advanced">Geavanceerd</string>
 
     <string name="title_apps">Apps</string>
@@ -39,10 +41,15 @@
     <string name="done">Klaar</string>
     <string name="add_extension">Een extensie toevoegen</string>
     <string name="cancel">Annuleren</string>
+    <string name="remove">Verwijderen</string>
+
+    <string name="undo">Onged. maken</string>
+    <string name="extension_removed_template">\'%1$s\' verwijderd.</string>
+    <string name="extensions_removed_template">%1$d extensies verwijderd.</string>
 
     <!-- These strings never appear in release builds; translation is very low priority -->
-    <string name="send_logs">Send debug log</string>
-    <string name="send_logs_chooser_title">Send logs using</string>
+    <string name="send_logs">Debuglog verzenden</string>
+    <string name="send_logs_chooser_title">Verzend logs met</string>
 
     <string name="prev_date_style">Vorige datumopmaak</string>
     <string name="prev_time_style">Vorige tijdsopmaak</string>
@@ -52,16 +59,19 @@
     <string name="incompatible_extension_menu_template">%1$s (Incompatibel)</string>
     <string name="incompatible_extension_title">Incompatibele extensie</string>
     <string name="incompatible_extension_message_search_play_template"><![CDATA[De
-        <b>%1$s</b> extenise is niet compatibel net deze versue van DashClock.
-        Zoeken voor een update voor deze extensie op Google Play?]]></string>
+        <b>%1$s</b>-extenise is niet compatibel met deze versie van DashClock.
+        Zoeken naar een update voor deze extensie op Google Play?]]></string>
     <string name="search_play">Zoeken op Google Play</string>
 
     <!-- About -->
     <string name="close">Sluiten</string>
     <string name="about">Over</string>
 
+    <string name="app_name_and_version" translatable="false"><![CDATA[
+        <b>DashClock</b>&nbsp;<font color="#888888">v%1$s</font>
+    ]]></string>
     <string name="about_body"><![CDATA[
-        Copyright 2012-2015 Google Inc. All Rights Reserved.<br>
+        Copyright 2012-2015 Google Inc. Alle rechten voorbehouden.<br>
         <a href="http://m.google.com/utos">Algemene voorwaaren</a>
         &nbsp;&nbsp;&middot;&nbsp;&nbsp;
         <a href="http://www.google.com/policies/privacy/">Privacyverklaring</a><br><br>
@@ -77,9 +87,11 @@
     <string name="weather_extension_description">
         Geeft de laatste weersinformatie voor jouw omgeving weer, waaronder de huidige temperatuur en weerscondities, maar ook de laatste weersvoorspellingen. Mogelijk gemaakt door Yahoo! Weather.
     </string>
-    <string name="title_weather_settings">Weer-extensie instellingen</string>
+    <string name="title_weather_settings">Weer extensie-instellingen</string>
     <string name="temperature_template">%1$s°</string>
+    <string name="weather_expanded_title_template" translatable="false">%1$s — %2$s</string>
     <string name="later_forecast_template">Later: %1$s</string>
+    <string name="weather_low_high_template" translatable="false">%1$s – %2$s</string>
     <string name="no_weather_data">Geen weersinformatie beschikbaar</string>
     <string name="no_location_data">Je locatie kon niet worden bepaald</string>
 
@@ -88,7 +100,7 @@
     <string name="gmail_extension_description">
         Geeft het aantal ongelezen e-mails weer van je Gmail inbox of Postvak Prioriteit.
     </string>
-    <string name="title_gmail_settings">Gmail-extensie instellingen</string>
+    <string name="title_gmail_settings">Gmail extensie-instellingen</string>
     <plurals name="gmail_title_template">
         <item quantity="other">%1$d ongelezen</item>
     </plurals>
@@ -99,13 +111,15 @@
         Geeft informatie weer over het volgende alarm, als er een is ingesteld.
     </string>
     <string name="next_alarm">Volgende alarm</string>
+    <string name="title_next_alarm_settings">Volgende alarm extensie-instellingen</string>
 
     <!-- Calendar -->
     <string name="calendar_extension_title">Agenda-afspraak</string>
     <string name="calendar_extension_description">
         Geeft informatie weer over de volgende afspraak in de agenda, als er een gepland is voor de komende uren.
     </string>
-    <string name="title_calendar_settings">Agenda-extensie instellingen</string>
+    <string name="title_calendar_settings">Agenda extensie-instellingen</string>
+    <string name="calendar_with_location_template" translatable="false">%1$s — %2$s</string>
     <plurals name="calendar_template_days">
         <item quantity="one">%1$s dag</item>
         <item quantity="other">%1$s dagen</item>
@@ -118,7 +132,7 @@
         <item quantity="other">%1$s min</item>
     </plurals>
     <string name="today">Vandaag</string>
-    <!--<string name="now">Now</string>-->
+    <string name="now">Nu</string>
 
     <!-- Missed calls -->
     <string name="missed_calls_extension_title">Gemiste oproepen</string>
@@ -142,6 +156,7 @@
         <item quantity="other">%1$s ongelezen gesprekken</item>
     </plurals>
     <string name="sms_body_template">Van: %1$s</string>
+    <string name="sms_body_all_participants_template">Met: %1$s</string>
 
     <!-- Welcome strings -->
     <string name="welcome_title">Jouw DashClock aanpassen</string>
@@ -149,5 +164,11 @@
         op het bovenstaande vinkje en je bent klaar om te beginnen! Maar waarom pas je DashClock niet aan met een paar <i>extensies</i>?
         \n\n<b>Extensies</b> geven relevante informatie weer, direct vanuit DashClock! Probeer ze uit door hieronder een paar extensies toe te voegen.
     </string>
+
+    <!-- Multiplexer -->
+    <string name="permission_desc_read_extension_data">Maakt het mogelijk om DashClock-extensiegegevens op te vragen</string>
+    <string name="permission_label_read_extension_data">DashClock-extensiegegevens opvragen</string>
+    <string name="permission_desc_bind_data_consumer">Maakt het mogelijk voor een app om verbruiksgegevens te gebruiken die gepubliceerd zijn door DashClock-extensies</string>
+    <string name="permission_label_bind_data_consumer">DashClock-extensieverbruiksgegevens opvragen</string>
 
 </resources>

--- a/main/src/main/res/values-nl/strings.xml
+++ b/main/src/main/res/values-nl/strings.xml
@@ -15,11 +15,6 @@
   -->
 
 <resources>
-    <string name="app_name" translatable="false">DashClock Widget</string>
-    <string name="widget_label" translatable="false">DashClock</string>
-
-    <string name="status_none" translatable="false">––</string>
-
     <string name="settings">Instellingen</string>
     <string name="more_options">Meer opties</string>
 
@@ -67,9 +62,6 @@
     <string name="close">Sluiten</string>
     <string name="about">Over</string>
 
-    <string name="app_name_and_version" translatable="false"><![CDATA[
-        <b>DashClock</b>&nbsp;<font color="#888888">v%1$s</font>
-    ]]></string>
     <string name="about_body"><![CDATA[
         Copyright 2012-2015 Google Inc. Alle rechten voorbehouden.<br>
         <a href="http://m.google.com/utos">Algemene voorwaaren</a>
@@ -89,9 +81,7 @@
     </string>
     <string name="title_weather_settings">Weer extensie-instellingen</string>
     <string name="temperature_template">%1$s°</string>
-    <string name="weather_expanded_title_template" translatable="false">%1$s — %2$s</string>
     <string name="later_forecast_template">Later: %1$s</string>
-    <string name="weather_low_high_template" translatable="false">%1$s – %2$s</string>
     <string name="no_weather_data">Geen weersinformatie beschikbaar</string>
     <string name="no_location_data">Je locatie kon niet worden bepaald</string>
 
@@ -119,7 +109,6 @@
         Geeft informatie weer over de volgende afspraak in de agenda, als er een gepland is voor de komende uren.
     </string>
     <string name="title_calendar_settings">Agenda extensie-instellingen</string>
-    <string name="calendar_with_location_template" translatable="false">%1$s — %2$s</string>
     <plurals name="calendar_template_days">
         <item quantity="one">%1$s dag</item>
         <item quantity="other">%1$s dagen</item>


### PR DESCRIPTION
Includes new strings from latest versions.

"Undo" is really long in Dutch ("ongedaan maken"), so it has been translated similar to the official Google apps ("onged. maken").