### PR TITLE
FIX: Set the mFragment instance onAttach to prevent that it is null.

### DIFF
--- a/main/src/main/java/com/google/android/apps/dashclock/configuration/BaseSettingsActivity.java
+++ b/main/src/main/java/com/google/android/apps/dashclock/configuration/BaseSettingsActivity.java
@@ -65,6 +65,11 @@ public abstract class BaseSettingsActivity extends AppCompatActivity {
     }
 
     @Override
+    public void onAttachFragment(android.app.Fragment fragment) {
+        mFragment = (ExtensionPreferenceFragment) fragment;
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             // TODO: if the previous activity on the stack isn't a ConfigurationActivity,


### PR DESCRIPTION
Fixes #853 
The crash is described in the issue with logs attached. 