### PR TITLE
FIX: Added config changes to ExtensionSettingsProxyActivity

### DIFF
--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -283,6 +283,7 @@
         <activity
             android:name="com.google.android.apps.dashclock.ExtensionSettingActivityProxy"
             android:theme="@android:style/Theme.NoDisplay"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:exported="false"/>
 
         <receiver android:name="com.google.android.apps.dashclock.ExtensionPackageChangeReceiver">


### PR DESCRIPTION
Just like `WidgetClickProxyActivity`, `configChanges` are added to `ExtensionSettingsProxyActivity` too. 
It is because it shouldn't be recreated.

Now, instead of `onCreate`, `onActivityResult` is called as expected. 

Fixes #855