### PR TITLE
Fix Yahoo Weather Extension

### DIFF
--- a/main/src/main/java/com/google/android/apps/dashclock/weather/YahooWeatherApiClient.java
+++ b/main/src/main/java/com/google/android/apps/dashclock/weather/YahooWeatherApiClient.java
@@ -185,7 +185,7 @@ class YahooWeatherApiClient {
 
         // first=tagname (admin1, locality3) second=woeid
         String primaryWoeid = null;
-        List<Pair<String,String>> alternateWoeids = new ArrayList<Pair<String, String>>();
+        List<Pair<String, String>> alternateWoeids = new ArrayList<Pair<String, String>>();
 
         HttpURLConnection connection = null;
         try {
@@ -389,7 +389,10 @@ class YahooWeatherApiClient {
 
     private static String buildWeatherQueryUrl(String woeid) {
         // http://developer.yahoo.com/weather/
-        return "http://weather.yahooapis.com/forecastrss?w=" + woeid + "&u=" + sWeatherUnits;
+        String query = "https://query.yahooapis.com/v1/public/yql?q="
+                + "SELECT * FROM weather.forecast WHERE woeid=" + woeid
+                + " and u=\'" + sWeatherUnits + "\'";
+        return query.replaceAll(" ", "%20");
     }
 
     private static String buildPlaceSearchUrl(Location l) {


### PR DESCRIPTION
Fixes #865.

Old yahoo forecast endpoint requires OAuth 1 for access. The new public API for making api calls is done through their YQL query: [https://query.yahooapis.com/v1/public/yql/?q=SELECT * FROM weather.forecast WHERE woeid=2459115 and u='F'](https://developer.yahoo.com/yql/console/?q=SELECT%20*%20FROM%20weather.forecast%20WHERE%20woeid=2459115%20and%20u=%27F%27)