### PR TITLE
Fix broken location lookup

### DIFF
--- a/main/src/main/java/com/google/android/apps/dashclock/weather/YahooWeatherApiClient.java
+++ b/main/src/main/java/com/google/android/apps/dashclock/weather/YahooWeatherApiClient.java
@@ -397,17 +397,19 @@ class YahooWeatherApiClient {
 
     private static String buildPlaceSearchUrl(Location l) {
         // GeoPlanet API
-        return "http://where.yahooapis.com/v1/places.q('"
-                + l.getLatitude() + "," + l.getLongitude() + "')"
-                + "?appid=" + YahooWeatherApiConfig.APP_ID;
+        String query = "https://query.yahooapis.com/v1/public/yql?q="
+                + "SELECT * FROM geo.places WHERE text=\"("
+                + l.getLatitude() + "," + l.getLongitude()
+                + ")\"";
+        return query.replaceAll(" ", "%20");
     }
 
     private static String buildPlaceSearchStartsWithUrl(String startsWith) {
         // GeoPlanet API
-        startsWith = startsWith.replaceAll("[^\\w ]+", "").replaceAll(" ", "%20");
-        return "http://where.yahooapis.com/v1/places.q('" + startsWith + "%2A');"
-                + "count=" + MAX_SEARCH_RESULTS
-                + "?appid=" + YahooWeatherApiConfig.APP_ID;
+        String query = "https://query.yahooapis.com/v1/public/yql?q="
+                + "SELECT * FROM geo.places WHERE text=\"" + startsWith
+                + "\" limit " + MAX_SEARCH_RESULTS;
+        return query.replaceAll(" ", "%20");
     }
 
     public static class LocationInfo {


### PR DESCRIPTION
Weather lookup is broken (again!) this time due to the sunsetting of the other API calls for looking up location. This causes `getLocationInfo` to fail to retrieve a WOEID and also prevents weather setting from showing autocomplete places.

This PR fixes this by migrating the remaining API calls to the public YQL query.
